### PR TITLE
Loss of other plugins cards for dashboard

### DIFF
--- a/src/Dashboard/Grid.php
+++ b/src/Dashboard/Grid.php
@@ -44,9 +44,15 @@ use Session;
 
 class Grid
 {
-    public static function getDashboardCards(): array
+    /**
+     * Get the description of additional cards for the dashboard
+     *
+     * @param null|array $cards existing cards
+     * @return array
+     */
+    public static function getDashboardCards($cards): array
     {
-        $cards = [];
+        $cards = $cards ?? [];
         // Declare the following cards only if we show / edit the quick report page of the plugin
         $in_carbon_report_page = self::in_carbon_report_page();
 


### PR DESCRIPTION
Impacts GLPI Inventory or any other plugin which declares dashboard cards

hook must get an array and return it completed with new cards

Closes : partner feedback