### PR TITLE
Invalidate usage_impact if lifespan changes

### DIFF
--- a/src/UsageInfo.php
+++ b/src/UsageInfo.php
@@ -39,6 +39,7 @@ use Computer as GlpiComputer;
 use DateInterval;
 use DateTime;
 use Glpi\Application\View\TemplateRenderer;
+use Glpi\DBAL\QueryExpression;
 use GlpiPlugin\Carbon\Dashboard\Provider;
 use GlpiPlugin\Carbon\Dashboard\Widget;
 use GlpiPlugin\Carbon\Impact\Type;
@@ -134,9 +135,40 @@ class UsageInfo extends CommonDBChild
     {
         parent::post_updateItem($history);
 
-        if (!$history) {
+        if (!in_array('planned_lifespan', $this->updates)) {
             return;
         }
+
+        // Planned lifespan has been updated
+        $infocom_table = getTableForItemType(Infocom::class);
+        $usage_impact_table = getTableForItemType(UsageImpact::class);
+        $usage_impact = new UsageImpact();
+        $found = $usage_impact->getFromDBByRequest([
+            'INNER JOIN' => [
+                $infocom_table => [
+                    'ON' => [
+                        $infocom_table => 'items_id',
+                        $usage_impact_table => 'items_id',
+                        [
+                            'AND' => [
+                                new QueryExpression(Infocom::getTableField('itemtype') . ' = ' . UsageImpact::getTableField('itemtype')),
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'WHERE' => [
+                UsageImpact::getTableField('itemtype') => $this->fields['itemtype'],
+                UsageImpact::getTableField('items_id') => $this->fields['items_id'],
+                [
+                    'NOT' => ['decommission_date' => null],
+                ],
+            ],
+        ]);
+        if (!$found) {
+            return;
+        }
+        $usage_impact->update(['recalculate' => 1] + $usage_impact->fields);
     }
 
     public function showForItem($ID, $withtemplate = '')

--- a/tests/src/AbstractTypeTest.php
+++ b/tests/src/AbstractTypeTest.php
@@ -33,9 +33,11 @@
 namespace GlpiPlugin\Carbon\Tests;
 
 use GlpiPlugin\Carbon\AbstractType;
+use PHPUnit\Framework\Attributes\CoversClass;
 use Session;
 use Symfony\Component\DomCrawler\Crawler;
 
+#[CoversClass(AbstractType::class)]
 abstract class AbstractTypeTest extends DbTestCase
 {
     protected static string $glpi_type_itemtype;

--- a/tests/units/UsageInfoTest.php
+++ b/tests/units/UsageInfoTest.php
@@ -36,6 +36,7 @@ use Computer as GlpiComputer;
 use Contact;
 use DBmysql;
 use GlpiPlugin\Carbon\EmbodiedImpact;
+use GlpiPlugin\Carbon\UsageImpact;
 use GlpiPlugin\Carbon\UsageInfo;
 use Infocom;
 use Monitor as GlpiMonitor;
@@ -360,5 +361,50 @@ class UsageInfoTest extends DbTestCase
         $usage_info = new UsageInfo();
         $result = $usage_info->getLifespanInHours($glpi_computer);
         $this->assertSame(43824, $result);
+    }
+
+
+    public function test_post_updateItem_invalidates_usage_impact_when_decommission_date_is_set_and_planned_lifespan_changes()
+    {
+        $glpi_asset = $this->createItem(GlpiComputer::class);
+        $usage_impact = $this->createItem(UsageImpact::class, [
+            'itemtype' => get_class($glpi_asset),
+            'items_id' => $glpi_asset->getID(),
+            'recalculate' => 0,
+        ]);
+        $infocom = $this->createItem(Infocom::class, [
+            'itemtype' => get_class($glpi_asset),
+            'items_id' => $glpi_asset->getID(),
+            'decommission_date' => '2026-06-06',
+        ]);
+        $usage_info = $this->createItem(UsageInfo::class, [
+            'itemtype' => get_class($glpi_asset),
+            'items_id' => $glpi_asset->getID(),
+        ]);
+        $usage_info->update(['planned_lifespan' => 60] + $usage_info->fields);
+        $usage_impact->getFromDB($usage_impact->getID());
+        $this->assertSame(1, $usage_impact->fields['recalculate']);
+    }
+
+    public function test_post_updateItem_does_not_invalidate_usage_impact_when_decommission_date_is_not_set()
+    {
+        $glpi_asset = $this->createItem(GlpiComputer::class);
+        $usage_impact = $this->createItem(UsageImpact::class, [
+            'itemtype' => get_class($glpi_asset),
+            'items_id' => $glpi_asset->getID(),
+            'recalculate' => 0,
+        ]);
+        $infocom = $this->createItem(Infocom::class, [
+            'itemtype' => get_class($glpi_asset),
+            'items_id' => $glpi_asset->getID(),
+            'decommission_date' => null,
+        ]);
+        $usage_info = $this->createItem(UsageInfo::class, [
+            'itemtype' => get_class($glpi_asset),
+            'items_id' => $glpi_asset->getID(),
+        ]);
+        $usage_info->update(['planned_lifespan' => 60] + $usage_info->fields);
+        $usage_impact->getFromDB($usage_impact->getID());
+        $this->assertSame(0, $usage_impact->fields['recalculate']);
     }
 }


### PR DESCRIPTION
TODO : implement other invalidations
#### in UsageInfo object
- if power consumption changes (model and type of each supported asset)
#### in Infocom object
- if decommission date changes
- if inventory entry date changes (with respect of precedence of the various dates)