### PR TITLE
Prepare tab for cache management

### DIFF
--- a/src/CronTask.php
+++ b/src/CronTask.php
@@ -70,19 +70,19 @@ class CronTask extends CommonGLPI
         if ($item instanceof GlpiCronTask) {
             /** @var GlpiCronTask $item */
             $cron_task = new self();
-            $cron_task->showForCronTask($item);
+            $cron_task->showForCronTask($item, $tabnum);
         }
         return true;
     }
 
-    public function showForCronTask(CommonDBTM $item)
+    public function showForCronTask(CommonDBTM $item, int $tabnum)
     {
         $itemtype = $item->fields['itemtype'];
         if (!in_array($itemtype, CronTaskProvider::getCronTaskTypes())) {
             return;
         }
         $crontask = new $itemtype();
-        $crontask->showForCronTask($item);
+        $crontask->showForCronTask($item, $tabnum);
     }
 
     /**

--- a/src/DataSource/AbstractCronTask.php
+++ b/src/DataSource/AbstractCronTask.php
@@ -50,16 +50,27 @@ abstract class AbstractCronTask extends CommonGLPI implements CronTaskInterface
 
     protected static string $downloadMethod;
 
+    protected const TAB_DIAGNOSIS = 0;
+    protected const TAB_CACHE = 1;
+
+
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
         return '';
     }
 
-    public function showForCronTask(CommonDBTM $item)
+    public function showForCronTask(CommonDBTM $item, int $tabnum)
     {
-        switch ($item->fields['name']) {
-            case static::$downloadMethod:
-                $this->showGapsReport();
+        if ($tabnum === self::TAB_DIAGNOSIS) {
+            switch ($item->fields['name']) {
+                case static::$downloadMethod:
+                    $this->showGapsReport();
+            }
+        } elseif ($tabnum === self::TAB_CACHE) {
+            switch ($item->fields['name']) {
+                case static::$downloadMethod:
+                    // TODO: implement tab to clear cached data in files/ folder
+            }
         }
     }
 

--- a/src/DataSource/CarbonIntensity/ElectricityMaps/CronTask.php
+++ b/src/DataSource/CarbonIntensity/ElectricityMaps/CronTask.php
@@ -50,7 +50,10 @@ class CronTask extends AbstractCronTask implements CronTaskInterface
 
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
-        return self::createTabEntry(__('Resource diagnosis', 'carbon'), 0);
+        return [
+            self::TAB_DIAGNOSIS => self::createTabEntry(__('Resource diagnosis', 'carbon'), 0),
+            // self::TAB_CACHE => self::createTabEntry(__('Cache', 'carbon'), 0),
+        ];
     }
 
     public static function enumerateTasks(): array

--- a/src/DataSource/CarbonIntensity/Rte/CronTask.php
+++ b/src/DataSource/CarbonIntensity/Rte/CronTask.php
@@ -53,7 +53,10 @@ class CronTask extends AbstractCronTask implements CronTaskInterface
 
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
-        return self::createTabEntry(__('Resource diagnosis', 'carbon'), 0);
+        return [
+            self::TAB_DIAGNOSIS => self::createTabEntry(__('Resource diagnosis', 'carbon'), 0),
+            // self::TAB_CACHE => self::createTabEntry(__('Cache', 'carbon'), 0),
+        ];
     }
 
     public static function enumerateTasks(): array


### PR DESCRIPTION
Allow the user to clear files of downloaded carbon intensity data, used as cache