### PR TITLE
feat(DataSource\Lca\Boavistappi\Config): change URL override method

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -35,3 +35,4 @@ jobs:
       glpi-version: "${{ matrix.glpi-version }}"
       php-version: "${{ matrix.php-version }}"
       db-image: "${{ matrix.db-image }}"
+      skip-changelog-check: true

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -24,9 +24,6 @@ jobs:
     with:
       glpi-version: "11.0.x"
   ci:
-    if: |
-      startsWith(github.ref_name, 'support/') &&
-      github.ref_name != 'support/1.0.0'
     name: "GLPI ${{ matrix.glpi-version }} - php:${{ matrix.php-version }} - ${{ matrix.db-image }}"
     needs: "generate-ci-matrix"
     strategy:

--- a/src/Config.php
+++ b/src/Config.php
@@ -119,7 +119,6 @@ class Config extends GlpiConfig
 
         $current_config = array_diff_key($current_config, array_flip($secured_config));
 
-        $hide_boaviztapi_base_url = (getenv(self::ENV_BOAVIZTAPI_BASE_URL) !== false);
         $renderer = TemplateRenderer::getInstance();
         $environment = $renderer->getEnvironment();
         if (!$environment->hasExtension(StringLoaderExtension::class)) {
@@ -130,7 +129,6 @@ class Config extends GlpiConfig
             'current_config'           => $current_config,
             'impact_engines'           => Engine::getAvailableBackends(),
             'include_configs'          => $include_configs,
-            'hide_boaviztapi_base_url' => $hide_boaviztapi_base_url,
             'action'                   => (isset($options['plugin_config']) ? Config::getFormURL() : GlpiConfig::getFormURL()),
         ]);
 
@@ -267,12 +265,6 @@ class Config extends GlpiConfig
      */
     public static function getPluginConfigurationValue(string $name): ?string
     {
-        if ($name === 'boaviztapi_base_url') {
-            $value = getenv(self::ENV_BOAVIZTAPI_BASE_URL);
-            if ($value !== false) {
-                return $value;
-            }
-        }
         return GlpiConfig::getConfigurationValue(self::CONFIG_CONTEXT, $name);
     }
 

--- a/src/DataSource/Lca/Boaviztapi/Config.php
+++ b/src/DataSource/Lca/Boaviztapi/Config.php
@@ -52,7 +52,7 @@ class Config implements ConfigInterface
     #[Override]
     public function getConfigTemplate(): string
     {
-        $hide_boaviztapi_base_url = (getenv(self::ENV_BOAVIZTAPI_BASE_URL) !== false);
+        $hide_boaviztapi_base_url = defined(self::ENV_BOAVIZTAPI_BASE_URL) && constant(self::ENV_BOAVIZTAPI_BASE_URL) !== null;
         $commercial_url = 'https://boavizta.org/';
         $twig = <<<TWIG
         {% import "components/form/fields_macros.html.twig" as fields %}
@@ -119,9 +119,9 @@ TWIG;
 
     public static function getConfigurationValue(string $name)
     {
-        if ($name === 'boaviztapi_base_url') {
-            $value = getenv(self::ENV_BOAVIZTAPI_BASE_URL);
-            if ($value !== false) {
+        if ($name === 'boaviztapi_base_url' && defined(self::ENV_BOAVIZTAPI_BASE_URL)) {
+            $value = constant(self::ENV_BOAVIZTAPI_BASE_URL);
+            if ($value !== null) {
                 return $value;
             }
         }

--- a/tests/units/ConfigTest.php
+++ b/tests/units/ConfigTest.php
@@ -246,21 +246,6 @@ class ConfigTest extends DbTestCase
         ]);
         $result = Config::getPluginConfigurationValue('foo');
         $this->assertEquals('bar', $result);
-
-        // Test an overridable configuration value, not overriden
-        GlpiConfig::setConfigurationValues('plugin:carbon', [
-            'boaviztapi_base_url' => 'bar',
-        ]);
-        $result = Config::getPluginConfigurationValue('boaviztapi_base_url');
-        $this->assertEquals('bar', $result);
-
-        // Test an overridable configuration value, overriden by an env var
-        GlpiConfig::setConfigurationValues('plugin:carbon', [
-            'boaviztapi_base_url' => 'baz',
-        ]);
-        putenv(Config::ENV_BOAVIZTAPI_BASE_URL . '=bar');
-        $result = Config::getPluginConfigurationValue('boaviztapi_base_url');
-        $this->assertEquals('bar', $result);
     }
 
     public function testSetPluginConfigurationValues()

--- a/tests/units/DataSource/Lca/Boaviztapi/ConfigTest.php
+++ b/tests/units/DataSource/Lca/Boaviztapi/ConfigTest.php
@@ -50,7 +50,7 @@ class ConfigTest extends DbTestCase
         $this->assertSame($expected, $result);
     }
 
-    public function testGetconfigTemplate()
+    public function test_getConfigTemplate_returns_full_template_when_boaviztapi_url_is_not_set_by_a_constant()
     {
         $context = [
             'current_config' => [
@@ -60,7 +60,7 @@ class ConfigTest extends DbTestCase
         ];
         $this->login('glpi', 'glpi');
         $instance = new Config();
-        putenv(Config::ENV_BOAVIZTAPI_BASE_URL); // Env var unset
+
         $result = $instance->getConfigTemplate();
         $renderer = TemplateRenderer::getInstance();
         if (!$renderer->getEnvironment()->hasExtension(StringLoaderExtension::class)) {
@@ -72,9 +72,25 @@ class ConfigTest extends DbTestCase
         $geocoding = $crawler->filter('input[type="checkbox"][name="geocoding_enabled"]');
         $this->assertEquals(1, $boaviztapi_url->count());
         $this->assertEquals(1, $geocoding->count());
+    }
 
-        putenv(Config::ENV_BOAVIZTAPI_BASE_URL . '=bar');
+    public function test_getConfigTemplate_returns_truncated_template_when_boaviztapi_url_is_set_by_a_constant()
+    {
+        $context = [
+            'current_config' => [
+                'boaviztapi_base_url' => 'foo',
+                'geocoding_enabled'   => true,
+            ],
+        ];
+        $this->login('glpi', 'glpi');
+        $instance = new Config();
+
+        define(Config::ENV_BOAVIZTAPI_BASE_URL, 'bar');
         $result = $instance->getConfigTemplate();
+        $renderer = TemplateRenderer::getInstance();
+        if (!$renderer->getEnvironment()->hasExtension(StringLoaderExtension::class)) {
+            $renderer->getEnvironment()->addExtension(new StringLoaderExtension());
+        }
         $result_html = $renderer->renderFromStringTemplate($result, $context);
         $crawler = new Crawler($result_html);
         $boaviztapi_url = $crawler->filter('input[name="boaviztapi_base_url"]');
@@ -116,21 +132,23 @@ class ConfigTest extends DbTestCase
         $this->assertEquals($expected, $result);
     }
 
-    public function testGetPluginConfigurationValue()
+    public function test_getPluginConfigurationValue_returns_data_from_config_when_not_overriden()
     {
         // Test an overridable configuration value, not overriden
         GlpiConfig::setConfigurationValues('plugin:carbon', [
             'boaviztapi_base_url' => 'bar',
         ]);
-        putenv(Config::ENV_BOAVIZTAPI_BASE_URL); // Env var unset
         $result = Config::getConfigurationValue('boaviztapi_base_url');
         $this->assertEquals('bar', $result);
+    }
 
+    public function test_getPluginConfigurationValue_returns_data_from_config_when_overriden()
+    {
         // Test an overridable configuration value, overriden by an env var
         GlpiConfig::setConfigurationValues('plugin:carbon', [
             'boaviztapi_base_url' => 'baz',
         ]);
-        putenv(Config::ENV_BOAVIZTAPI_BASE_URL . '=bar');
+        define(Config::ENV_BOAVIZTAPI_BASE_URL, 'bar');
         $result = Config::getConfigurationValue('boaviztapi_base_url');
         $this->assertEquals('bar', $result);
     }


### PR DESCRIPTION
use a regular constant instead of en environment variable, forced and fixed URL is now settable in downstream.php cleanup related dead code on Config class