### PR TITLE
Handle mixed sources for embodied impact

### DIFF
--- a/src/DataSource/Lca/Boaviztapi/Client.php
+++ b/src/DataSource/Lca/Boaviztapi/Client.php
@@ -37,6 +37,7 @@ use Dropdown;
 use GlpiPlugin\Carbon\Config as CarbonConfig;
 use GlpiPlugin\Carbon\DataSource\Lca\AbstractClient;
 use GlpiPlugin\Carbon\DataSource\RestApiClientInterface;
+use GlpiPlugin\Carbon\DataTracking\AbstractTracked;
 use GlpiPlugin\Carbon\DataTracking\TrackedFloat;
 use GlpiPlugin\Carbon\Impact\Type;
 use GlpiPlugin\Carbon\Source;
@@ -252,7 +253,7 @@ class Client extends AbstractClient
      *
      * @param array $response
      * @param string $scope (must be either embedded or use)
-     * @return array
+     * @return array<int, null|AbstractTracked>
      */
     public function parseResponse(array $response, string $scope): array
     {
@@ -273,7 +274,7 @@ class Client extends AbstractClient
         return $impacts;
     }
 
-    protected function parseCriteria(string $name, $impact): ?TrackedFloat
+    protected function parseCriteria(string $name, string|array $impact): ?TrackedFloat
     {
         if ($impact === 'not implemented') {
             return null;

--- a/src/Impact/Embodied/AbstractEmbodiedImpact.php
+++ b/src/Impact/Embodied/AbstractEmbodiedImpact.php
@@ -78,7 +78,12 @@ abstract class AbstractEmbodiedImpact implements EmbodiedImpactInterface
         }
     }
 
-    abstract protected function getVersion(): string;
+    public function getEnginename(): string
+    {
+        return $this->engine;
+    }
+
+    abstract public function getVersion(): string;
 
     #[Override]
     public function setLimit(int $limit)
@@ -221,7 +226,7 @@ abstract class AbstractEmbodiedImpact implements EmbodiedImpactInterface
     /**
      * Do the environmental impact evaluation of an asset
      *
-     * @return ?array
+     * @return ?array<int, null|AbstractTracked>
      */
     abstract protected function doEvaluation(): ?array;
 

--- a/src/Impact/Embodied/Boavizta/AbstractAsset.php
+++ b/src/Impact/Embodied/Boavizta/AbstractAsset.php
@@ -77,7 +77,7 @@ abstract class AbstractAsset extends AbstractEmbodiedImpact implements AssetInte
     }
 
     #[Override]
-    protected function getVersion(): string
+    public function getVersion(): string
     {
         if (self::$engine_version !== 'unknown') {
             return self::$engine_version;

--- a/src/Impact/Embodied/Engine.php
+++ b/src/Impact/Embodied/Engine.php
@@ -68,10 +68,6 @@ class Engine extends CommonGLPI
     {
         $itemtype = get_class($item);
 
-        if (self::hasModelData($item)) {
-            return self::getInternalEngineFromItemtype($item);
-        }
-
         $embodied_impact_namespace = Config::getEmbodiedImpactEngine();
         /** @var class-string<AbstractEmbodiedImpact> $embodied_impact_class */
         $embodied_impact_class = $embodied_impact_namespace . '\\' . $itemtype;
@@ -80,14 +76,18 @@ class Engine extends CommonGLPI
             return self::getInternalEngineFromItemtype($item);
         }
 
-        /** @var AbstractEmbodiedImpact $embodied_impact */
-        $embodied_impact = new $embodied_impact_class($item);
+        /** @var AbstractEmbodiedImpact $external_embodied_impact_engine */
+        $external_embodied_impact_engine = new $embodied_impact_class($item);
         try {
-            return self::configureEngine($embodied_impact);
+            $external_embodied_impact_engine = self::configureEngine($external_embodied_impact_engine);
         } catch (RuntimeException $e) {
-            // If the engine cannot be configured, it is not usable
-            return null;
+            $external_embodied_impact_engine = null;
         }
+        if (self::hasModelData($item)) {
+            return self::getInternalEngineFromItemtype($item, $external_embodied_impact_engine);
+        }
+
+        return $external_embodied_impact_engine;
     }
 
     /**
@@ -95,16 +95,17 @@ class Engine extends CommonGLPI
      * This is a fallback engine
      *
      * @param CommonDBTM $item item to analyze
+     * @param ?EmbodiedImpactInterface $external_embodied_impact_engine
      * @return ?EmbodiedImpactInterface
      */
-    public static function getInternalEngineFromItemtype(CommonDBTM $item): ?EmbodiedImpactInterface
+    public static function getInternalEngineFromItemtype(CommonDBTM $item, ?EmbodiedImpactInterface $external_embodied_impact_engine = null): ?EmbodiedImpactInterface
     {
         $itemtype = get_class($item);
         $embodied_impact_class = 'GlpiPlugin\\Carbon\\Impact\\Embodied\Internal' . '\\' . $itemtype;
         if (!class_exists($embodied_impact_class) || !is_subclass_of($embodied_impact_class, AbstractEmbodiedImpact::class)) {
             return null;
         }
-        $embodied_impact = new $embodied_impact_class($item);
+        $embodied_impact = new $embodied_impact_class($item, $external_embodied_impact_engine);
         return $embodied_impact;
     }
 

--- a/src/Impact/Embodied/Internal/AbstractAsset.php
+++ b/src/Impact/Embodied/Internal/AbstractAsset.php
@@ -33,6 +33,7 @@
 namespace GlpiPlugin\Carbon\Impact\Embodied\Internal;
 
 use CommonDBTM;
+use DBmysql;
 use GlpiPlugin\Carbon\DataTracking\TrackedFloat;
 use GlpiPlugin\Carbon\Impact\Embodied\AbstractEmbodiedImpact;
 use GlpiPlugin\Carbon\Impact\Type;
@@ -48,8 +49,16 @@ abstract class AbstractAsset extends AbstractEmbodiedImpact
     /** @var string $engine_version Version of the calculation engine */
     protected static string $engine_version = '1';
 
+    protected ?AbstractEmbodiedImpact $external_embodied_impact_engine = null;
+
+    public function __construct(CommonDBTM $item, ?AbstractEmbodiedImpact $external_embodied_impact_engine)
+    {
+        parent::__construct($item);
+        $this->external_embodied_impact_engine = $external_embodied_impact_engine;
+    }
+
     #[Override]
-    protected function getVersion(): string
+    public function getVersion(): string
     {
         return self::$engine_version;
     }
@@ -57,33 +66,49 @@ abstract class AbstractAsset extends AbstractEmbodiedImpact
     #[Override]
     protected function doEvaluation(): array
     {
-        /** @var class-string<CommonDBTM> */
-        $glpi_model_itemtype = static::$itemtype . 'Model';
-        $glpi_model_fk = getForeignKeyFieldForItemType($glpi_model_itemtype);
-        if ($glpi_model_itemtype::isNewID($this->item->fields[$glpi_model_fk])) {
-            return [];
-        }
-
-        /** @var CommonDBTM|false $model */
-        $model = getItemForItemtype('GlpiPlugin\\Carbon\\' . $glpi_model_itemtype);
-        $model->getFromDBByCrit([
-            $glpi_model_fk => $this->item->fields[$glpi_model_fk],
-        ]);
-        if ($model->isNewItem()) {
-            return [];
-        }
+        /** @var DBmysql $DB */
+        global $DB;
 
         $impacts = [];
-        $types = Type::getImpactTypes();
-        foreach ($types as $type) {
-            if (!isset($model->fields[$type]) || empty($model->fields[$type])) {
-                continue;
+
+        $glpi_model_itemtype = static::$itemtype . 'Model';
+        $glpi_model_table = getTableForItemType($glpi_model_itemtype);
+        $glpi_model_fk = getForeignKeyFieldForItemType($glpi_model_itemtype);
+        $model_itemtype = 'GlpiPlugin\\Carbon\\' . $glpi_model_itemtype;
+        $model = getItemForItemtype($model_itemtype);
+        if ($model !== false) {
+            $model_table = getTableForItemtype($model_itemtype);
+            $model->getFromDBByRequest([
+                'INNER JOIN' => [
+                    $glpi_model_table => [
+                        'ON' => [
+                            $glpi_model_table => 'id',
+                            $model_table => $glpi_model_fk,
+                        ],
+                    ],
+                ],
+                'WHERE' => [
+                    $glpi_model_fk => $this->item->fields[$glpi_model_fk],
+                ],
+            ]);
+
+            $types = Type::getImpactTypes();
+
+            foreach ($types as $type) {
+                if (!isset($model->fields[$type]) || empty($model->fields[$type])) {
+                    continue;
+                }
+                $impacts[Type::getImpactId($type)] = new TrackedFloat(
+                    $model->fields[$type],
+                    null,
+                    $model->fields["{$type}_quality"]
+                );
             }
-            $impacts[Type::getImpactId($type)] = new TrackedFloat(
-                $model->fields[$type],
-                null,
-                $model->fields["{$type}_quality"]
-            );
+        }
+        if ($this->external_embodied_impact_engine !== null) {
+            $external_impacts = $this->external_embodied_impact_engine->doEvaluation();
+            $this->engine .= ' + ' . $this->external_embodied_impact_engine->getEngineName() . ' ' . $this->external_embodied_impact_engine->getVersion();
+            $impacts = array_replace($external_impacts, $impacts);
         }
 
         return $impacts;

--- a/tests/src/Impact/Embodied/Internal/AbstractEmbodiedImpactTest.php
+++ b/tests/src/Impact/Embodied/Internal/AbstractEmbodiedImpactTest.php
@@ -32,7 +32,12 @@
 
 namespace GlpiPlugin\Carbon\Tests\Impact\Embodied\Internal;
 
+use GlpiPlugin\Carbon\DataTracking\AbstractTracked;
+use GlpiPlugin\Carbon\DataTracking\TrackedFloat;
+use GlpiPlugin\Carbon\EmbodiedImpact;
 use GlpiPlugin\Carbon\Impact\Embodied\AbstractEmbodiedImpact;
+use GlpiPlugin\Carbon\Impact\Embodied\Boavizta\AbstractAsset;
+use GlpiPlugin\Carbon\Impact\Embodied\Internal\Computer;
 use GlpiPlugin\Carbon\Tests\Impact\Embodied\AbstractCommonEmbodiedImpactTest;
 use PHPUnit\Framework\Attributes\CoversClass;
 
@@ -42,4 +47,37 @@ class AbstractEmbodiedImpactTest extends AbstractCommonEmbodiedImpactTest
     protected static string $itemtype = '';
     protected static string $itemtype_type = '';
     protected static string $itemtype_model = '';
+
+    public function test_doEvaluation_uses_user_input_impacts_when_user_input_impacts_are_set()
+    {
+        $glpi_asset_type = $this->createItem(static::$itemtype_type);
+        $glpi_asset_model = $this->createItem(static::$itemtype_model);
+        $asset_type = $this->createItem('GlpiPlugin\\Carbon\\' . static::$itemtype_type, [
+            getForeignKeyFieldForItemType(static::$itemtype_type) => $glpi_asset_type->getID(),
+        ]);
+        $asset_model = $this->createItem('GlpiPlugin\\Carbon\\' . static::$itemtype_model, [
+            getForeignKeyFieldForItemtype(static::$itemtype_model) => $glpi_asset_model->getID(),
+            'gwp' => 1024,
+            'gwp_quality' => AbstractTracked::DATA_QUALITY_MANUAL,
+        ]);
+        $asset = $this->createItem(static::$itemtype, [
+            getForeignKeyFieldForItemType(static::$itemtype_type) => $glpi_asset_type->getID(),
+            getForeignKeyFieldForItemType(static::$itemtype_model) => $glpi_asset_model->getID(),
+        ]);
+
+        $external_engine = $this->createStub(AbstractAsset::class);
+        $external_engine->method('doEvaluation')->willReturn([
+            // 0 is the ID of GWP, see impact types
+            0 => new TrackedFloat(2048, null, AbstractTracked::DATA_QUALITY_ESTIMATED),
+        ]);
+        $instance = new Computer($asset, $external_engine);
+        $instance->evaluateItem();
+
+        $embodied_impact = $this->getItem(EmbodiedImpact::class, [
+            'itemtype' => get_class($asset),
+            'items_id' => $asset->getID(),
+        ]);
+
+        $this->assertEquals(1024, $embodied_impact->fields['gwp']);
+    }
 }


### PR DESCRIPTION
Allow to use manual impacts to enrich external data

If Boaviztapi (as an example) does not provides data for a impact criteria, or if the user wants to ignore a specific impact criteria and use a specific value, then the manual data takes precedence, if its quality is not 'unspecified'.