### PR TITLE
fix(dashboard): merge cards and widget instead of redefine

### DIFF
--- a/src/Dashboard/Grid.php
+++ b/src/Dashboard/Grid.php
@@ -40,9 +40,8 @@ use Session;
 
 class Grid
 {
-    public static function getDashboardCards(): array
+    public static function getDashboardCards(array $cards = []): array
     {
-        $cards = [];
         // Declare the following cards only if we show / edit the quick report page of the plugin
         $in_carbon_report_page = self::in_carbon_report_page();
 

--- a/src/Dashboard/Grid.php
+++ b/src/Dashboard/Grid.php
@@ -40,8 +40,9 @@ use Session;
 
 class Grid
 {
-    public static function getDashboardCards(array $cards = []): array
+    public static function getDashboardCards(?array $cards = null): array
     {
+        $cards ??= [];
         // Declare the following cards only if we show / edit the quick report page of the plugin
         $in_carbon_report_page = self::in_carbon_report_page();
 

--- a/src/Dashboard/Widget.php
+++ b/src/Dashboard/Widget.php
@@ -47,9 +47,9 @@ use Toolbox as GlpiToolbox;
 
 class Widget extends GlpiDashboardWidget
 {
-    public static function WidgetTypes(): array
+    public static function WidgetTypes(array $types = []): array
     {
-        $types = [
+        $types = array_merge($types, [
             // Informative
             'information_video' => [
                 'label'    => __('Environmental impact information video', 'carbon'),
@@ -111,7 +111,7 @@ class Widget extends GlpiDashboardWidget
                 'width'    => 6,
                 'height'   => 3,
             ],
-        ];
+        ]);
 
         // Data diagnostic
         if (in_array(Computer::class, PLUGIN_CARBON_TYPES)) {

--- a/src/Dashboard/Widget.php
+++ b/src/Dashboard/Widget.php
@@ -47,9 +47,9 @@ use Toolbox as GlpiToolbox;
 
 class Widget extends GlpiDashboardWidget
 {
-    public static function WidgetTypes(array $types = []): array
+    public static function WidgetTypes(?array $types = null): array
     {
-        $types = array_merge($types, [
+        $types = array_merge($types ?? [], [
             // Informative
             'information_video' => [
                 'label'    => __('Environmental impact information video', 'carbon'),


### PR DESCRIPTION
Some plugins (such as Advanced Dashboard) also use the _**Hooks::DASHBOARD_***_ hooks and are loaded before the Carbon plugin.

Without this change, the Carbon plugin redefines the _**Hooks::DASHBOARD_***_ hooks without taking into account the data already added by previously loaded plugins.