### PR TITLE
Fix(Dashboard): Fix empty card for other plugins

### DIFF
--- a/src/Dashboard/Grid.php
+++ b/src/Dashboard/Grid.php
@@ -40,9 +40,11 @@ use Session;
 
 class Grid
 {
-    public static function getDashboardCards(): array
+    public static function getDashboardCards($cards = []): array
     {
-        $cards = [];
+        if (is_null($cards)) {
+            $cards = [];
+        }
         // Declare the following cards only if we show / edit the quick report page of the plugin
         $in_carbon_report_page = self::in_carbon_report_page();
 


### PR DESCRIPTION
Fix !44577

The way the Carbon plugin currently computes reports prevents other plugins from contributing their own report data.

The `$cards` variable is systematically reset with:

```php
$cards = [];
```

However, this variable is actually passed as a parameter and may already contain cards computed by other plugins. Resetting it at this stage discards any previously generated data and prevents proper aggregation of dashboard cards across plugins.

The implementation should preserve the existing contents of `$cards` and append or merge the Dashboard plugin's cards instead of reinitializing the array.
