### PR TITLE
Discourage guessing the URL of the API

### DIFF
--- a/src/DataSource/Lca/Boaviztapi/Config.php
+++ b/src/DataSource/Lca/Boaviztapi/Config.php
@@ -67,6 +67,10 @@ class Config implements ConfigInterface
 TWIG;
         if (!$hide_boaviztapi_base_url) {
             $twig .= <<<TWIG
+            {{ fields.smallTitle(
+                __('Boavizta does not provide any service. You are responsible for hosting the server. Read the documentation of the plugin.', 'carbon'),
+            ) }}
+
             {{ fields.textField(
                 'boaviztapi_base_url',
                 current_config['boaviztapi_base_url'],


### PR DESCRIPTION
People seem to not read the doc, Boavizta does not provide any instance of the server.

This PR adds a smallTitle in the boavizta config section; see the screenshot.

<img width="1915" height="872" alt="image" src="https://github.com/user-attachments/assets/9fa4445d-7a0c-41ba-a945-d55a7e8542e6" />


Relates to: #278 and internal ticket 45025 