### PR TITLE
Fix: prevent missing build assets regression

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -36,3 +36,21 @@ jobs:
       php-version: "${{ matrix.php-version }}"
       db-image: "${{ matrix.db-image }}"
       skip-changelog-check: true
+  verify-build-assets:
+    name: "Verify frontend build assets"
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@v7"
+      - uses: "actions/setup-node@v7"
+        with:
+          node-version-file: "package.json"
+      - name: "Install dependencies (triggers webpack build)"
+        run: "npm install"
+      - name: "Check generated assets are present"
+        run: |
+          for file in public/lib/apexcharts.js public/lib/carbon.js public/lib/carbon.css; do
+            if [ ! -s "$file" ]; then
+              echo "::error::Missing or empty build asset: $file"
+              exit 1
+            fi
+          done

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 dist/
 node_modules/
 vendor/
+public/images/
+public/lib/
 .vscode/
 .gh_token
 *.min.*

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "apexcharts": "^3.49.0"
             },
             "devDependencies": {
-                "copy-webpack-plugin": "^14.0.0",
+                "copy-webpack-plugin": "^13.0.0",
                 "css-loader": "^6.11.0",
                 "file-loader": "^6.2.0",
                 "glob": "^11.0.2",
@@ -863,19 +863,20 @@
             "peer": true
         },
         "node_modules/copy-webpack-plugin": {
-            "version": "14.0.0",
-            "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-14.0.0.tgz",
-            "integrity": "sha512-3JLW90aBGeaTLpM7mYQKpnVdgsUZRExY55giiZgLuX/xTQRUs1dOCwbBnWnvY6Q6rfZoXMNwzOQJCSZPppfqXA==",
+            "version": "13.0.1",
+            "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-13.0.1.tgz",
+            "integrity": "sha512-J+YV3WfhY6W/Xf9h+J1znYuqTye2xkBUIGyTPWuBAT27qajBa5mR4f8WBmfDY3YjRftT2kqZZiLi1qf0H+UOFw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "glob-parent": "^6.0.1",
                 "normalize-path": "^3.0.0",
                 "schema-utils": "^4.2.0",
-                "serialize-javascript": "^7.0.3",
+                "serialize-javascript": "^6.0.2",
                 "tinyglobby": "^0.2.12"
             },
             "engines": {
-                "node": ">= 20.9.0"
+                "node": ">= 18.12.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -2738,6 +2739,16 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/randombytes": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+            "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "^5.1.0"
+            }
+        },
         "node_modules/read-pkg": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-6.0.0.tgz",
@@ -2959,6 +2970,27 @@
                 "queue-microtask": "^1.2.2"
             }
         },
+        "node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
         "node_modules/schema-utils": {
             "version": "4.3.3",
             "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
@@ -2991,12 +3023,13 @@
             }
         },
         "node_modules/serialize-javascript": {
-            "version": "7.0.7",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.7.tgz",
-            "integrity": "sha512-YAy8Od6KV+uuwUuU50np8fGB/Aues6Y0nAhA9y/hId74PlKUcme4pXcBD46NWKr1Q4osN/iseZ17YqO1XfmI8g==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+            "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
             "dev": true,
-            "engines": {
-                "node": ">=20.0.0"
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "randombytes": "^2.1.0"
             }
         },
         "node_modules/shallow-clone": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
     "description": "Measurement of carbon emissions of GLPI devices",
     "license": "GPL-3.0-or-later",
     "version": "1.3.0",
+    "engines": {
+        "node": ">= 18.12.0"
+    },
     "dependencies": {
         "apexcharts": "^3.49.0"
     },
@@ -11,7 +14,7 @@
         "postinstall": "npm run-script build"
     },
     "devDependencies": {
-        "copy-webpack-plugin": "^14.0.0",
+        "copy-webpack-plugin": "^13.0.0",
         "css-loader": "^6.11.0",
         "file-loader": "^6.2.0",
         "glob": "^11.0.2",


### PR DESCRIPTION
## Problem
On Node < 20, installing the plugin silently produced an empty public/lib directory, so the built JS/CSS assets were missing after packaging.

## Fix
Revert copy-webpack-plugin to a Node 18 compatible version, pin the minimum Node version in package.json, ignore the generated public/ directory, and add a CI job that fails the build if the generated assets are missing or empty.

ref: !45641